### PR TITLE
Add basic tests for components, reducers, and actions

### DIFF
--- a/client/actions/appActions.spec.js
+++ b/client/actions/appActions.spec.js
@@ -1,0 +1,11 @@
+// Test actions not indirectly tested in reducers
+import { expect } from 'chai';
+
+import {  
+  emitProfileRequest,
+  localNotification
+} from './appActions';
+
+describe('(Actions) app', () => {
+
+});

--- a/client/actions/campaignActions.spec.js
+++ b/client/actions/campaignActions.spec.js
@@ -1,0 +1,20 @@
+// Test actions not indirectly tested in reducers
+import { expect } from 'chai';
+
+import {  
+  requestStopSending,
+  completeStopSending,
+  stopSending,
+  getCampaigns,
+  postCreateTemplate,
+  postCreateCampaign,
+  deleteCampaigns,
+  postSendCampaign,
+  postTestEmail,
+  getTemplates,
+  deleteTemplates
+} from './campaignActions';
+
+describe('(Actions) campaign', () => {
+
+});

--- a/client/actions/listActions.spec.js
+++ b/client/actions/listActions.spec.js
@@ -1,0 +1,14 @@
+// Test actions not indirectly tested in reducers
+import { expect } from 'chai';
+
+import {  
+  getListSubscribers,
+  getLists,
+  submitCSV,
+  deleteListSubscribers,
+  deleteLists
+} from './listActions';
+
+describe('(Actions) list', () => {
+
+});

--- a/client/actions/permissionActions.spec.js
+++ b/client/actions/permissionActions.spec.js
@@ -1,0 +1,21 @@
+// Test actions not indirectly tested in reducers
+import { expect } from 'chai';
+
+import {  
+  getGrantPermissions,
+  postGrantPermission,
+  deleteGrantedPermissions,
+  getActivePermissions,
+  deleteActivePermissions,
+  getReceivedPermissionOffers,
+  postAcceptReceivedOffers,
+  deleteRejectReceivedOffers,
+  getGrantOfferedPermissions,
+  deleteGrantOfferedPermissions,
+  becomeAnotherUser,
+  becomeSelf
+} from './permissionActions';
+
+describe('(Actions) permission', () => {
+
+});

--- a/client/actions/settingsActions.spec.js
+++ b/client/actions/settingsActions.spec.js
@@ -1,0 +1,11 @@
+// Test actions not indirectly tested in reducers
+import { expect } from 'chai';
+
+import {  
+  getBooleanForAssignedSettings,
+  changeSettings
+} from './settingsActions';
+
+describe('(Actions) settings', () => {
+
+});

--- a/client/components/404/index.spec.js
+++ b/client/components/404/index.spec.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import NotFound from '../404';
+
+const wrapper = shallow(<NotFound />);
+
+describe('(Component) NotFound', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/admin-lte/Footer.spec.js
+++ b/client/components/admin-lte/Footer.spec.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import Footer from './Footer';
+
+const wrapper = shallow(<Footer />);
+
+describe('(Component) Footer', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/admin-lte/Header.spec.js
+++ b/client/components/admin-lte/Header.spec.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import Header from './Header';
+
+const mockProps = (overrides) => ({
+  user: {},
+  ws_notification: [],
+  consumeNotification: () => {},
+  ...overrides
+});
+
+const wrapper = shallow(<Header {...mockProps()} />);
+
+describe('(Component) Header', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/admin-lte/RightSidebar.spec.js
+++ b/client/components/admin-lte/RightSidebar.spec.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import RightSidebar from './RightSidebar';
+
+const mockProps = (overrides) => ({
+  touch: () => {},
+  valid: true,
+  pristine: true,
+  submitting: true,
+  changeAccount: () => {},
+  changeAccountToSelf: () => {},
+  isGettingActivePermissions: true,
+  activePermissionsEmails: [],
+  activeAccount: {},
+  ...overrides
+});
+
+const wrapper = shallow(<RightSidebar {...mockProps()} />);
+
+describe('(Component) RightSidebar', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/admin-lte/Sidebar.spec.js
+++ b/client/components/admin-lte/Sidebar.spec.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import Sidebar from './Sidebar';
+
+const mockProps = (overrides) => ({
+  user: {},
+  activeAccount: {}
+});
+
+const wrapper = shallow(<Sidebar {...mockProps()} />);
+
+describe('(Component) Sidebar', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/admin-lte/WS-Notification.spec.js
+++ b/client/components/admin-lte/WS-Notification.spec.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import WSNotification from './WS-Notification';
+
+const mockProps = (overrides) => ({
+  message: '',
+  icon: '',
+  iconColour: '',
+  consumeNotification: () => {},
+  index: 0,
+  ...overrides
+});
+
+const wrapper = shallow(<WSNotification {...mockProps()} />);
+
+describe('(Component) WSNotification', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/analytics/CampaignReportsTable.spec.js
+++ b/client/components/analytics/CampaignReportsTable.spec.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import CampaignReportsTable from './CampaignReportsTable';
+
+const mockProps = (overrides) => ({
+  data: [],
+  ...overrides
+});
+
+const wrapper = shallow(<CampaignReportsTable {...mockProps()} />);
+
+describe('(Component) CampaignReportsTable', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/campaigns/CreateCampaignForm.spec.js
+++ b/client/components/campaigns/CreateCampaignForm.spec.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import CreateCampaignForm from './CreateCampaignForm';
+
+const mockProps = (overrides) => ({
+  touch: () => {},
+  valid: true,
+  pristine: true,
+  submitting: true,
+  nextPage: () => {},
+  reset: () => {},
+  lists: [],
+  templates: [],
+  applyTemplate: () => {},
+  textEditorType: '',
+  passResetToState: () => {},
+  initialValues: {},
+  clearTextEditor: () => {},
+  ...overrides
+});
+
+const wrapper = shallow(<CreateCampaignForm {...mockProps()} />);
+
+describe('(Component) CreateCampaignForm', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/campaigns/ManageCampaigns.spec.js
+++ b/client/components/campaigns/ManageCampaigns.spec.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import ManageCampaigns from './ManageCampaigns';
+
+const wrapper = shallow(<ManageCampaigns />);
+
+describe('(Component) ManageCampaigns', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/campaigns/ManageCampaignsGraph.spec.js
+++ b/client/components/campaigns/ManageCampaignsGraph.spec.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import ManageCampaignsGraph from './ManageCampaignsGraph';
+
+const mockProps = (overrides) => ({
+  data: [],
+  ...overrides
+});
+
+const wrapper = shallow(<ManageCampaignsGraph {...mockProps()} />);
+
+describe('(Component) ManageCampaignsGraph', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/campaigns/ManageCampaignsTable.spec.js
+++ b/client/components/campaigns/ManageCampaignsTable.spec.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import ManageCampaignsTable from './ManageCampaignsTable';
+
+const mockProps = (overrides) => ({
+  data: [],
+  deleteRows: () => {},
+  getCampaignView: () => {},
+  ...overrides
+});
+
+const wrapper = shallow(<ManageCampaignsTable {...mockProps()} />);
+
+describe('(Component) ManageCampaignsTable', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/campaigns/PreviewCampaignForm.spec.js
+++ b/client/components/campaigns/PreviewCampaignForm.spec.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import PreviewCampaignForm from './PreviewCampaignForm';
+
+const mockProps = (overrides) => ({
+  handleSubmit: () => {},
+  lastPage: () => {},
+  form: { values: {} },
+  campaignView: {},
+  ...overrides
+});
+
+const wrapper = shallow(<PreviewCampaignForm {...mockProps()} />);
+
+describe('(Component) PreviewCampaignForm', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/common/DisabledLink.spec.js
+++ b/client/components/common/DisabledLink.spec.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import DisabledLink from './DisabledLink';
+
+const mockProps = (overrides) => ({
+  icon: '',
+  children: '',
+  ...overrides
+});
+
+const mockContext = {
+  router: { isActive: (a, b) => true }
+};
+
+const wrapper = shallow(<DisabledLink {...mockProps()} />, { context: mockContext });
+
+describe('(Component) DisabledLink', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/common/FormRenderWrappers.spec.js
+++ b/client/components/common/FormRenderWrappers.spec.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import {
+  renderSettingsDropdownList,
+  renderDropdownList,
+  renderCombobox,
+  renderSettingsField,
+  renderField,
+  renderEditorTypeRadio,
+  renderTextEditor
+} from './FormRenderWrappers';
+
+describe('(Component) renderSettingsDropdownList', () => {
+  const wrapper = shallow(<renderSettingsDropdownList />);
+
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});
+
+describe('(Component) renderDropdownList', () => {
+  const wrapper = shallow(<renderDropdownList />);
+  
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});
+
+describe('(Component) renderCombobox', () => {
+  const wrapper = shallow(<renderCombobox />);
+  
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});
+
+describe('(Component) renderSettingsField', () => {
+  const wrapper = shallow(<renderSettingsField />);
+  
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});
+
+describe('(Component) renderField', () => {
+  const wrapper = shallow(<renderField />);
+  
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});
+
+describe('(Component) renderEditorTypeRadio', () => {
+  const wrapper = shallow(<renderEditorTypeRadio />);
+  
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});
+
+describe('(Component) renderTextEditor', () => {
+  const wrapper = shallow(<renderTextEditor />);
+  
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/common/SidebarLink.spec.js
+++ b/client/components/common/SidebarLink.spec.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import SidebarLink from './SidebarLink';
+
+const mockProps = (overrides) => ({
+  to: '',
+  icon: '',
+  children: '',
+  ...overrides
+});
+
+const mockContext = {
+  router: { isActive: (a, b) => true }
+};
+
+const wrapper = shallow(<SidebarLink {...mockProps()} />, { context: mockContext });
+
+describe('(Component) SidebarLink', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/common/SidebarTreeview.spec.js
+++ b/client/components/common/SidebarTreeview.spec.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import SidebarTreeview from './SidebarTreeview';
+
+const mockProps = (overrides) => ({
+  name: '',
+  icon: '',
+  ...overrides
+});
+
+const mockContext = {
+  router: { isActive: (a, b) => true }
+};
+
+const wrapper = shallow(<SidebarTreeview {...mockProps()} />, { context: mockContext });
+
+describe('(Component) SidebarTreeview', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/common/TextEditorPlain.spec.js
+++ b/client/components/common/TextEditorPlain.spec.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import TextEditorPlain from './TextEditorPlain';
+
+const mockProps = (overrides) => ({
+  value: '',
+  onChange: () => {},
+  ...overrides
+});
+
+const wrapper = shallow(<TextEditorPlain {...mockProps()} />);
+
+describe('(Component) TextEditorPlain', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/common/TextEditorRich.spec.js
+++ b/client/components/common/TextEditorRich.spec.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import TextEditorRich from './TextEditorRich';
+
+const mockProps = (overrides) => ({
+  value: '',
+  onChange: () => {},
+  ...overrides
+});
+
+const wrapper = shallow(<TextEditorRich {...mockProps()} />);
+
+describe('(Component) TextEditorRich', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/dashboard/UserInfo.spec.js
+++ b/client/components/dashboard/UserInfo.spec.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import UserInfo from './UserInfo';
+
+const mockProps = (overrides) => ({
+  user: {},
+  totalSentCount: 0,
+  ...overrides
+});
+
+const wrapper = shallow(<UserInfo {...mockProps()} />);
+
+describe('(Component) UserInfo', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/lists/ErrorsList.spec.js
+++ b/client/components/lists/ErrorsList.spec.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import ErrorsList from './ErrorsList';
+
+const mockProps = (overrides) => ({
+  errors: [],
+  ...overrides
+});
+
+const wrapper = shallow(<ErrorsList {...mockProps()} />);
+
+describe('(Component) ErrorsList', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/lists/ListSignupFormCreator.js
+++ b/client/components/lists/ListSignupFormCreator.js
@@ -5,9 +5,9 @@ import { connect } from 'react-redux';
 
 import { notify } from '../../actions/notificationActions';
 
+const mapDispatchToProps = { notify };
 
-@connect(null, { notify })
-export default class ListSignupFormCreator extends React.Component {
+export class ListSignupFormCreator extends React.Component {
   constructor(props) {
     super(props);
 
@@ -73,3 +73,4 @@ export default class ListSignupFormCreator extends React.Component {
   }
 }
 
+export default connect(null, mapDispatchToProps)(ListSignupFormCreator);

--- a/client/components/lists/ListSignupFormCreator.spec.js
+++ b/client/components/lists/ListSignupFormCreator.spec.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import { ListSignupFormCreator } from './ListSignupFormCreator';
+
+const mockProps = (overrides) => ({
+  showModal: true,
+  subscribeKey: '',
+  notify: () => {},
+  ...overrides
+});
+
+const wrapper = shallow(<ListSignupFormCreator {...mockProps()} />);
+
+describe('(Component) ListSignupFormCreator', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/lists/ManageLists.spec.js
+++ b/client/components/lists/ManageLists.spec.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import ManageLists from './ManageLists';
+
+const wrapper = shallow(<ManageLists />);
+
+describe('(Component) ManageLists', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/lists/ManageListsTable.spec.js
+++ b/client/components/lists/ManageListsTable.spec.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import ManageListsTable from './ManageListsTable';
+
+const mockProps = (overrides) => ({
+  data: [],
+  deleteRows: () => {},
+  ...overrides
+});
+
+const wrapper = shallow(<ManageListsTable {...mockProps()} />);
+
+describe('(Component) ManageListsTable', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/lists/ManageSubscribersTable.spec.js
+++ b/client/components/lists/ManageSubscribersTable.spec.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import ManageSubscribersTable from './ManageSubscribersTable';
+
+const mockProps = (overrides) => ({
+  data: [],
+  deleteRows: () => {},
+  onPageChange: () => {},
+  additionalFields: [],
+  listId: 0,
+  total: 0,
+  ...overrides
+});
+
+const wrapper = shallow(<ManageSubscribersTable {...mockProps()} />);
+
+describe('(Component) ManageSubscribersTable', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/lists/SubscribersTable.spec.js
+++ b/client/components/lists/SubscribersTable.spec.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import SubscribersTable from './SubscribersTable';
+
+const mockProps = (overrides) => ({
+  subscribers: [],
+  fields: [],
+  ...overrides
+});
+
+const wrapper = shallow(<SubscribersTable {...mockProps()} />);
+
+describe('(Component) SubscribersTable', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/permissions/GrantPermissionForm.spec.js
+++ b/client/components/permissions/GrantPermissionForm.spec.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import GrantPermissionForm from './GrantPermissionForm';
+
+const mockProps = (overrides) => ({
+  touch: () => {},
+  valid: true,
+  pristine: true,
+  submitting: true,
+  reset: () => {},
+  handleSubmit: () => {},
+  ...overrides
+});
+
+const wrapper = shallow(<GrantPermissionForm {...mockProps()} />);
+
+describe('(Component) GrantPermissionForm', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/permissions/ManageActivePermissionsTable.spec.js
+++ b/client/components/permissions/ManageActivePermissionsTable.spec.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import ManageActivePermissionsTable from './ManageActivePermissionsTable';
+
+const mockProps = (overrides) => ({
+  data: [],
+  deletePermissionRows: () => {},
+  ...overrides
+});
+
+const wrapper = shallow(<ManageActivePermissionsTable {...mockProps()} />);
+
+describe('(Component) ManageActivePermissionsTable', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/permissions/ManageGrantOfferedPermissionsTable.spec.js
+++ b/client/components/permissions/ManageGrantOfferedPermissionsTable.spec.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import ManageGrantOfferedPermissionsTable from './ManageGrantOfferedPermissionsTable';
+
+const mockProps = (overrides) => ({
+  data: [],
+  deletePermissionRows: () => {},
+  ...overrides
+});
+
+const wrapper = shallow(<ManageGrantOfferedPermissionsTable {...mockProps()} />);
+
+describe('(Component) ManageGrantOfferedPermissionsTable', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/permissions/ManageGrantedPermissionsTable.spec.js
+++ b/client/components/permissions/ManageGrantedPermissionsTable.spec.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import ManageGrantedPermissionsTable from './ManageGrantedPermissionsTable';
+
+const mockProps = (overrides) => ({
+  data: [],
+  deletePermissionRows: () => {},
+  ...overrides
+});
+
+const wrapper = shallow(<ManageGrantedPermissionsTable {...mockProps()} />);
+
+describe('(Component) ManageGrantedPermissionsTable', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/permissions/ManageReceivedPermissionOffersTable.spec.js
+++ b/client/components/permissions/ManageReceivedPermissionOffersTable.spec.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import ManageReceivedPermissionOffersTable from './ManageReceivedPermissionOffersTable';
+
+const mockProps = (overrides) => ({
+  data: [],
+  rejectRows: () => {},
+  acceptRows: () => {},
+  ...overrides
+});
+
+const wrapper = shallow(<ManageReceivedPermissionOffersTable {...mockProps()} />);
+
+describe('(Component) ManageReceivedPermissionOffersTable', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/templates/CreateTemplateForm.spec.js
+++ b/client/components/templates/CreateTemplateForm.spec.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import CreateTemplateForm from './CreateTemplateForm';
+
+const mockProps = (overrides) => ({
+  touch: () => {},
+  valid: true,
+  pristine: true,
+  submitting: true,
+  nextPage: () => {},
+  reset: () => {},
+  validationFailed: () => {},
+  textEditorType: '',
+  passResetToState: () => {},
+  clearTextEditor: () => {},
+  ...overrides
+});
+
+const wrapper = shallow(<CreateTemplateForm {...mockProps()} />);
+
+describe('(Component) CreateTemplateForm', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/templates/ManageTemplatesTable.spec.js
+++ b/client/components/templates/ManageTemplatesTable.spec.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import ManageTemplatesTable from './ManageTemplatesTable';
+
+const mockProps = (overrides) => ({
+  data: [],
+  deleteRows: () => {},
+  getTemplateView: () => {},
+  ...overrides
+});
+
+const wrapper = shallow(<ManageTemplatesTable {...mockProps()} />);
+
+describe('(Component) ManageTemplatesTable', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/components/templates/PreviewTemplateForm.spec.js
+++ b/client/components/templates/PreviewTemplateForm.spec.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import PreviewTemplateForm from './PreviewTemplateForm';
+
+const mockProps = (overrides) => ({
+  handleSubmit: () => {},
+  lastPage: () => {},
+  form: { values: { emailBody: '' } },
+  templateView: {},
+  submitting: true,
+  ...overrides
+});
+
+const wrapper = shallow(<PreviewTemplateForm {...mockProps()} />);
+
+describe('(Component) PreviewTemplateForm', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/containers/AddEmail.js
+++ b/client/containers/AddEmail.js
@@ -4,9 +4,9 @@ import { connect } from 'react-redux';
 
 import { addSubscribers } from '../actions/listActions';
 
+const mapDispatchToProps = { addSubscribers };
 
-@connect(null, { addSubscribers })
-export default class AddEmail extends React.Component {
+export class AddEmail extends React.Component {
 
   handleSubmit(e) {
     e.preventDefault();
@@ -42,3 +42,5 @@ export default class AddEmail extends React.Component {
 AddEmail.propTypes = {
   addSubscribers: React.PropTypes.func.isRequired
 };
+
+export default connect(null, mapDispatchToProps)(AddEmail);

--- a/client/containers/AddEmail.spec.js
+++ b/client/containers/AddEmail.spec.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import { AddEmail } from './AddEmail';
+
+const mockProps = (overrides) => ({
+  addSubscribers: () => {}
+});
+
+const wrapper = shallow(<AddEmail {...mockProps()} />);
+
+describe('(Container) AddEmail', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/containers/App.js
+++ b/client/containers/App.js
@@ -29,8 +29,9 @@ function mapStateToProps(state) {
   };
 }
 
-@connect(mapStateToProps, { emitProfileRequest, consumeNotification, getActivePermissions, becomeAnotherUser, becomeSelf })
-export default class App extends Component {
+const mapDispatchToProps = { emitProfileRequest, consumeNotification, getActivePermissions, becomeAnotherUser, becomeSelf };
+
+export class App extends Component {
 
   static propTypes = {
     children: PropTypes.element.isRequired,
@@ -124,3 +125,5 @@ export default class App extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(App);

--- a/client/containers/App.spec.js
+++ b/client/containers/App.spec.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import { App } from './App';
+
+const mockProps = (overrides) => ({
+  children: <div></div>,
+  user: {},
+  ws_notification: [],
+  isGettingActivePermissions: true,
+  activePermissionsEmails: [],
+  accountForm: {},
+  activeAccount: {},
+  emitProfileRequest: () => {},
+  consumeNotification: () => {},
+  getActivePermissions: () => {},
+  becomeAnotherUser: () => {},
+  becomeSelf: () => {},
+  route: {},
+  location: { pathname: '' }
+});
+
+const mockContext = {
+  router: { isActive: (a, b) => true }
+};
+
+const wrapper = shallow(<App {...mockProps()} />, { context: mockContext });
+
+describe('(Container) App', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/containers/Dashboard.js
+++ b/client/containers/Dashboard.js
@@ -11,8 +11,7 @@ function mapStateToProps(state) {
   };
 }
 
-@connect(mapStateToProps, null)
-export default class Dashboard extends Component {
+export class Dashboard extends Component {
   render() {
     const totalSentCount = this.props.campaigns.reduce((total, campaign) => total + campaign['campaignanalytic.totalSentCount'], 0);
 
@@ -37,3 +36,5 @@ Dashboard.propTypes = {
   children: PropTypes.element,
   user: PropTypes.object
 };
+
+export default connect(mapStateToProps)(Dashboard);

--- a/client/containers/Dashboard.spec.js
+++ b/client/containers/Dashboard.spec.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import { Dashboard } from './Dashboard';
+
+const mockProps = (overrides) => ({
+  children: <div></div>,
+  user: {},
+  campaigns: []
+});
+
+const wrapper = shallow(<Dashboard {...mockProps()} />);
+
+describe('(Container) Dashboard', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/containers/Notifications.js
+++ b/client/containers/Notifications.js
@@ -10,8 +10,9 @@ function mapStateToProps(state) {
   };
 }
 
-@connect(mapStateToProps, { consume })
-export default class Notifications extends Component {
+const mapDispatchToProps = { consume };
+
+export class Notifications extends Component {
   static propTypes = {
     notifications: PropTypes.array.isRequired,
     consume: PropTypes.func.isRequired
@@ -77,3 +78,5 @@ export default class Notifications extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(Notifications);

--- a/client/containers/Notifications.spec.js
+++ b/client/containers/Notifications.spec.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import { Notifications } from './Notifications';
+
+const mockProps = (overrides) => ({
+  notifications: [],
+  consume: () => {}
+});
+
+const wrapper = shallow(<Notifications {...mockProps()} />);
+
+describe('(Container) Notifications', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/containers/Settings.js
+++ b/client/containers/Settings.js
@@ -13,7 +13,7 @@ import 'react-widgets/dist/css/react-widgets.css';
 
 const regions = ['us-west-2', 'us-east-1', 'eu-west-1']; // AWS SES regions
 
-function getState(state) {
+function mapStateToProps(state) {
   return {
     loading: state.settings.loading,
     fieldsExist: state.settings.fieldsExist,
@@ -21,6 +21,8 @@ function getState(state) {
     status: state.settings.status
   };
 }
+
+const mapDispatchToProps = { getBooleanForAssignedSettings, changeSettings, notify };
 
 const validate = values=> {
   // See ref https://docs.aws.amazon.com/IAM/latest/APIReference/API_AccessKey.html
@@ -50,9 +52,7 @@ const validate = values=> {
   return errors;
 };
 
-@reduxForm({ form: 'settings',  destroyOnUnmount: false, validate })
-@connect(getState, { getBooleanForAssignedSettings, changeSettings, notify })
-export default class Settings extends Component {
+export class Settings extends Component {
 
   static propTypes = {
     // connect
@@ -200,3 +200,8 @@ export default class Settings extends Component {
     );
   }
 }
+
+export default 
+  connect(mapStateToProps, mapDispatchToProps)
+  (reduxForm({ form: 'settings',  destroyOnUnmount: false, validate })
+  (Settings));

--- a/client/containers/Settings.spec.js
+++ b/client/containers/Settings.spec.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import { Settings } from './Settings';
+
+const mockProps = (overrides) => ({
+  getBooleanForAssignedSettings: () => {},
+  changeSettings: () => {},
+  notify: () => {},
+  loading: true,
+  fieldsExist: {},
+  touch: () => {},
+  valid: true,
+  pristine: true,
+  submitting: true,
+  reset: () => {}
+});
+
+const wrapper = shallow(<Settings {...mockProps()} />);
+
+describe('(Container) Settings', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/containers/analytics/CampaignReports.spec.js
+++ b/client/containers/analytics/CampaignReports.spec.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import CampaignReports from './CampaignReports';
+
+const mockProps = (overrides) => ({
+  isGetting: true
+});
+
+const wrapper = shallow(<CampaignReports {...mockProps()} />);
+
+describe('(Container) CampaignReports', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/containers/campaigns/CampaignView.js
+++ b/client/containers/campaigns/CampaignView.js
@@ -22,8 +22,9 @@ function mapStateToProps(state) {
   };
 }
 
-@connect(mapStateToProps, { getCampaigns, postSendCampaign, postTestEmail, stopSending, notify })
-export default class CampaignView extends Component {
+const mapDispatchToProps = { getCampaigns, postSendCampaign, postTestEmail, stopSending, notify };
+
+export class CampaignView extends Component {
 
   static propTypes = {
     // actions
@@ -254,3 +255,5 @@ export default class CampaignView extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(CampaignView);

--- a/client/containers/campaigns/CampaignView.spec.js
+++ b/client/containers/campaigns/CampaignView.spec.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import { CampaignView } from './CampaignView';
+
+const mockProps = (overrides) => ({
+  postSendCampaign: () => {},
+  postTestEmail: () => {},
+  getCampaigns: () => {},
+  stopSending: () => {},
+  notify: () => {},
+  campaigns: [],
+  isGetting: true,
+  sendCampaign: () => {},
+  isPostingSendCampaign: true,
+  sendCampaignResponse: '',
+  sendCampaignStatus: 0,
+  isPostingSendTest: true,
+  sendTestEmailResponse: '',
+  sendTestEmailStatus: 0,
+  params: {}
+});
+
+const wrapper = shallow(<CampaignView {...mockProps()} />);
+
+describe('(Container) CampaignView', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/containers/campaigns/CampaignView.spec.js
+++ b/client/containers/campaigns/CampaignView.spec.js
@@ -10,7 +10,7 @@ const mockProps = (overrides) => ({
   getCampaigns: () => {},
   stopSending: () => {},
   notify: () => {},
-  campaigns: [],
+  campaigns: [{ slug: 'mockSlug', totalCampaignSubscribers: 0 }],
   isGetting: true,
   sendCampaign: () => {},
   isPostingSendCampaign: true,
@@ -19,7 +19,7 @@ const mockProps = (overrides) => ({
   isPostingSendTest: true,
   sendTestEmailResponse: '',
   sendTestEmailStatus: 0,
-  params: {}
+  params: { slug: 'mockSlug'}
 });
 
 const wrapper = shallow(<CampaignView {...mockProps()} />);

--- a/client/containers/campaigns/CreateCampaign.js
+++ b/client/containers/campaigns/CreateCampaign.js
@@ -20,8 +20,9 @@ function mapStateToProps(state) {
   };
 }
 
-@connect(mapStateToProps, { postCreateCampaign, getLists, getTemplates, initialize, notify })
-export default class CreateCampaign extends Component {
+const mapDispatchToProps = { postCreateCampaign, getLists, getTemplates, initialize, notify };
+
+export class CreateCampaign extends Component {
 
   static propTypes = {
     form: PropTypes.object,
@@ -136,3 +137,5 @@ export default class CreateCampaign extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(CreateCampaign);

--- a/client/containers/campaigns/CreateCampaign.spec.js
+++ b/client/containers/campaigns/CreateCampaign.spec.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import { CreateCampaign } from './CreateCampaign';
+
+const mockProps = (overrides) => ({
+  form: { values: {} },
+  isPosting: true,
+  postCreateCampaign: () => {},
+  getLists: () => {},
+  lists: [],
+  isGetting: true,
+  getTemplates: () => {},
+  templates: [],
+  initialize: () => {},
+  notify: () => {}
+});
+
+const mockContext = {
+  router: { isActive: (a, b) => true }
+};
+
+const wrapper = shallow(<CreateCampaign {...mockProps()} />, { context: mockContext });
+
+describe('(Container) CreateCampaign', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/containers/campaigns/ManageCampaignsBox.js
+++ b/client/containers/campaigns/ManageCampaignsBox.js
@@ -15,8 +15,9 @@ function mapStateToProps(state) {
   };
 }
 
-@connect(mapStateToProps, { getCampaigns, deleteCampaigns })
-export default class ManageCampaignsBox extends Component {
+const mapDispatchToProps = { getCampaigns, deleteCampaigns };
+
+export class ManageCampaignsBox extends Component {
 
   static propTypes = {
     campaigns: PropTypes.array.isRequired,
@@ -69,3 +70,5 @@ export default class ManageCampaignsBox extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(ManageCampaignsBox);

--- a/client/containers/campaigns/ManageCampaignsBox.spec.js
+++ b/client/containers/campaigns/ManageCampaignsBox.spec.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import { ManageCampaignsBox } from './ManageCampaignsBox';
+
+const mockProps = (overrides) => ({
+  campaigns: [],
+  isGetting: true,
+  getCampaigns: () => {},
+  deleteCampaigns: () => {}
+});
+
+const mockContext = {
+  router: { isActive: (a, b) => true }
+};
+
+const wrapper = shallow(<ManageCampaignsBox {...mockProps()} />, { context: mockContext });
+
+describe('(Container) ManageCampaignsBox', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/containers/common/TextEditor.spec.js
+++ b/client/containers/common/TextEditor.spec.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import TextEditor from './TextEditor';
+
+const mockProps = (overrides) => ({
+  input: {},
+  textEditorType: ''
+});
+
+const wrapper = shallow(<TextEditor {...mockProps()} />);
+
+describe('(Container) TextEditor', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/containers/lists/CreateList.js
+++ b/client/containers/lists/CreateList.js
@@ -17,8 +17,9 @@ function mapStateToProps(state) {
   };
 }
 
-@connect(mapStateToProps, { submitCSV, notify })
-export default class CreateList extends Component {
+const mapDispatchToProps = { submitCSV, notify };
+
+export class CreateList extends Component {
 
   static propTypes = {
     submitCSV: PropTypes.func.isRequired,
@@ -133,3 +134,5 @@ export default class CreateList extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(CreateList);

--- a/client/containers/lists/CreateList.spec.js
+++ b/client/containers/lists/CreateList.spec.js
@@ -7,7 +7,6 @@ import { CreateList } from './CreateList';
 const mockProps = (overrides) => ({
   submitCSV: () => {},
   notify: () => {},
-  getLists: () => {},
   lists: [],
   isGetting: true
 });

--- a/client/containers/lists/CreateList.spec.js
+++ b/client/containers/lists/CreateList.spec.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import { CreateList } from './CreateList';
+
+const mockProps = (overrides) => ({
+  submitCSV: () => {},
+  notify: () => {},
+  getLists: () => {},
+  lists: [],
+  isGetting: true
+});
+
+const mockContext = {
+  router: { isActive: (a, b) => true }
+};
+
+const wrapper = shallow(<CreateList {...mockProps()} />, { context: mockContext });
+
+describe('(Container) CreateList', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/containers/lists/ImportCSV.js
+++ b/client/containers/lists/ImportCSV.js
@@ -16,8 +16,7 @@ function mapStateToProps(state) {
   };
 }
 
-@connect(mapStateToProps, null)
-export default class ImportCSV extends Component {
+export class ImportCSV extends Component {
 
   static propTypes = {
     handleCSVSubmit: PropTypes.func.isRequired,
@@ -159,3 +158,5 @@ export default class ImportCSV extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps)(ImportCSV);

--- a/client/containers/lists/ImportCSV.spec.js
+++ b/client/containers/lists/ImportCSV.spec.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import { ImportCSV } from './ImportCSV';
+
+const mockProps = (overrides) => ({
+  handleCSVSubmit: () => {},
+  isPosting: true,
+  notification: () => {},
+  upload: {}
+});
+
+const wrapper = shallow(<ImportCSV {...mockProps()} />);
+
+describe('(Container) ImportCSV', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/containers/lists/ManageListSubscribers.js
+++ b/client/containers/lists/ManageListSubscribers.js
@@ -14,8 +14,9 @@ function mapStateToProps(state) {
   };
 }
 
-@connect(mapStateToProps, { deleteListSubscribers, getListSubscribers })
-export default class ManageListSubscribers extends Component {
+const mapDispatchToProps = { deleteListSubscribers, getListSubscribers };
+
+export class ManageListSubscribers extends Component {
 
   static propTypes = {
     subscribers: PropTypes.array.isRequired,
@@ -23,7 +24,8 @@ export default class ManageListSubscribers extends Component {
     deleteListSubscribers: PropTypes.func.isRequired,
     getListSubscribers: PropTypes.func.isRequired,
     params: PropTypes.object,
-    totalListSubscribers: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+    totalListSubscribers: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    additionalFields: PropTypes.array.isRequired
   }
 
   constructor() {
@@ -74,3 +76,5 @@ export default class ManageListSubscribers extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(ManageListSubscribers);

--- a/client/containers/lists/ManageListSubscribers.spec.js
+++ b/client/containers/lists/ManageListSubscribers.spec.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import { ManageListSubscribers } from './ManageListSubscribers';
+
+const mockProps = (overrides) => ({
+  subscribers: [],
+  isGetting: true,
+  deleteListSubscribers: () => {},
+  getListSubscribers: () => {},
+  params: { listId: 0 },
+  totalListSubscribers: 0,
+  additionalFields: []
+});
+
+const wrapper = shallow(<ManageListSubscribers {...mockProps()} />);
+
+describe('(Container) ManageListSubscribers', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/containers/lists/ManageListsBox.js
+++ b/client/containers/lists/ManageListsBox.js
@@ -14,8 +14,9 @@ function mapStateToProps(state) {
   };
 }
 
-@connect(mapStateToProps, { getLists, deleteLists })
-export default class ManageList extends Component {
+const mapDispatchToProps = { getLists, deleteLists };
+
+export class ManageListsBox extends Component {
 
   static propTypes = {
     getLists: PropTypes.func.isRequired,
@@ -74,3 +75,5 @@ export default class ManageList extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(ManageListsBox);

--- a/client/containers/lists/ManageListsBox.spec.js
+++ b/client/containers/lists/ManageListsBox.spec.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import { ManageListsBox } from './ManageListsBox';
+
+const mockProps = (overrides) => ({
+  getLists: () => {},
+  lists: [],
+  isGetting: true,
+  deleteLists: () => {}
+});
+
+const wrapper = shallow(<ManageListsBox {...mockProps()} />);
+
+describe('(Container) ManageListsBox', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/containers/lists/UploadFileModal.spec.js
+++ b/client/containers/lists/UploadFileModal.spec.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import UploadFileModal from './UploadFileModal';
+
+const mockProps = (overrides) => ({
+  handleNewFile: () => {}
+});
+
+const wrapper = shallow(<UploadFileModal {...mockProps()} />);
+
+describe('(Container) UploadFileModal', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/containers/permissions/GrantPermissions.js
+++ b/client/containers/permissions/GrantPermissions.js
@@ -15,8 +15,9 @@ function mapStateToProps(state) {
   };
 }
 
-@connect(mapStateToProps, { notify, postGrantPermission })
-export default class GrantPermissions extends Component {
+const mapDispatchToProps = { notify, postGrantPermission };
+
+export class GrantPermissions extends Component {
 
   static propTypes = {
     // redux
@@ -77,3 +78,5 @@ export default class GrantPermissions extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(GrantPermissions);

--- a/client/containers/permissions/GrantPermissions.spec.js
+++ b/client/containers/permissions/GrantPermissions.spec.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import { GrantPermissions } from './GrantPermissions';
+
+const mockProps = (overrides) => ({
+  form: {},
+  isPosting: true,
+  response: {},
+  notify: () => {},
+  postGrantPermission: () => {}
+});
+
+const wrapper = shallow(<GrantPermissions {...mockProps()} />);
+
+describe('(Container) GrantPermissions', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/containers/permissions/OfferedPermissions.js
+++ b/client/containers/permissions/OfferedPermissions.js
@@ -24,11 +24,12 @@ function mapStateToProps(state) {
   };
 }
 
-@connect(mapStateToProps, {
+const mapDispatchToProps = {
   getGrantPermissions, deleteGrantedPermissions,
   getGrantOfferedPermissions, deleteGrantOfferedPermissions,
-  notify })
-export default class GrantPermissions extends Component {
+  notify };
+
+export class OfferedPermissions extends Component {
 
   static propTypes = {
     // redux
@@ -121,3 +122,5 @@ export default class GrantPermissions extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(OfferedPermissions);

--- a/client/containers/permissions/OfferedPermissions.spec.js
+++ b/client/containers/permissions/OfferedPermissions.spec.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import { OfferedPermissions } from './OfferedPermissions';
+
+const mockProps = (overrides) => ({
+  isGettingGrantedPermissions: true,
+  grantedPermissions: [],
+  isGettingGrantOfferedPermissions: true,
+  grantOfferedPermissions: [],
+  getGrantPermissions: () => {},
+  deleteGrantedPermissions: () => {},
+  getGrantOfferedPermissions: () => {},
+  deleteGrantOfferedPermissions: () => {},
+  notify: () => {}
+});
+
+const wrapper = shallow(<OfferedPermissions {...mockProps()} />);
+
+describe('(Container) OfferedPermissions', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/containers/permissions/ReceivedPermissions.js
+++ b/client/containers/permissions/ReceivedPermissions.js
@@ -27,11 +27,12 @@ function mapStateToProps(state) {
   };
 }
 
-@connect(mapStateToProps, {
+const mapDispatchToProps = {
   getReceivedPermissionOffers, deleteRejectReceivedOffers, postAcceptReceivedOffers,
   getActivePermissions, deleteActivePermissions,
-  notify })
-export default class GrantPermissions extends Component {
+  notify };
+
+export class ReceivedPermissions extends Component {
 
   static propTypes = {
     // redux
@@ -134,3 +135,5 @@ export default class GrantPermissions extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(ReceivedPermissions);

--- a/client/containers/permissions/ReceivedPermissions.spec.js
+++ b/client/containers/permissions/ReceivedPermissions.spec.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import { ReceivedPermissions } from './ReceivedPermissions';
+
+const mockProps = (overrides) => ({
+  isGettingReceivedPermissionOffers: true,
+  receivedPermissionOffers: [],
+  isGettingActivePermissions: true,
+  activePermissions: [],
+  getReceivedPermissionOffers: () => {},
+  deleteRejectReceivedOffers: () => {},
+  getActivePermissions: () => {},
+  deleteActivePermissions: () => {},
+  postAcceptReceivedOffers: () => {},
+  notify: () => {}
+});
+
+const wrapper = shallow(<ReceivedPermissions {...mockProps()} />);
+
+describe('(Container) ReceivedPermissions', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/containers/templates/CreateTemplate.js
+++ b/client/containers/templates/CreateTemplate.js
@@ -17,8 +17,9 @@ function mapStateToProps(state) {
   };
 }
 
-@connect(mapStateToProps, { postCreateTemplate, notify })
-export default class Templates extends Component {
+const mapDispatchToProps = { postCreateTemplate, notify };
+
+export class CreateTemplate extends Component {
 
   static propTypes = {
     form: PropTypes.object,
@@ -113,3 +114,5 @@ export default class Templates extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(CreateTemplate);

--- a/client/containers/templates/CreateTemplate.spec.js
+++ b/client/containers/templates/CreateTemplate.spec.js
@@ -8,7 +8,6 @@ const mockProps = (overrides) => ({
   form: { values: {} },
   isPosting: true,
   postCreateTemplate: () => {},
-  getTemplates: () => {},
   templates: [],
   isGetting: true,
   notify: () => {}

--- a/client/containers/templates/CreateTemplate.spec.js
+++ b/client/containers/templates/CreateTemplate.spec.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import { CreateTemplate } from './CreateTemplate';
+
+const mockProps = (overrides) => ({
+  form: { values: {} },
+  isPosting: true,
+  postCreateTemplate: () => {},
+  getTemplates: () => {},
+  templates: [],
+  isGetting: true,
+  notify: () => {}
+});
+
+const wrapper = shallow(<CreateTemplate {...mockProps()} />);
+
+describe('(Container) CreateTemplate', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/containers/templates/ManageTemplates.js
+++ b/client/containers/templates/ManageTemplates.js
@@ -15,8 +15,9 @@ function mapStateToProps(state) {
   };
 }
 
-@connect(mapStateToProps, { getTemplates, deleteTemplates, notify })
-export default class Templates extends Component {
+const mapDispatchToProps = { getTemplates, deleteTemplates, notify };
+
+export class ManageTemplates extends Component {
 
   static propTypes = {
     form: PropTypes.object,
@@ -74,3 +75,5 @@ export default class Templates extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(ManageTemplates);

--- a/client/containers/templates/ManageTemplates.spec.js
+++ b/client/containers/templates/ManageTemplates.spec.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import { ManageTemplates } from './ManageTemplates';
+
+const mockProps = (overrides) => ({
+  form: {},
+  getTemplates: () => {},
+  templates: [],
+  isGetting: true,
+  deleteTemplates: () => {},
+  notify: () => {}
+});
+
+
+const mockContext = {
+  router: { isActive: (a, b) => true }
+};
+
+const wrapper = shallow(<ManageTemplates {...mockProps()} />, { context: mockContext });
+
+describe('(Container) ManageTemplates', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/containers/templates/TemplateView.js
+++ b/client/containers/templates/TemplateView.js
@@ -13,8 +13,9 @@ function mapStateToProps(state) {
   };
 }
 
-@connect(mapStateToProps, { notify, getTemplates })
-export default class CampaignView extends Component {
+const mapDispatchToProps = { notify, getTemplates };
+
+export class TemplateView extends Component {
 
   static propTypes = {
     notify: PropTypes.func.isRequired,
@@ -80,3 +81,5 @@ export default class CampaignView extends Component {
     );
   }
 }
+
+export default connect(mapStateToProps, mapDispatchToProps)(TemplateView);

--- a/client/containers/templates/TemplateView.spec.js
+++ b/client/containers/templates/TemplateView.spec.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import { TemplateView } from './TemplateView';
+
+const mockProps = (overrides) => ({
+  notify: () => {},
+  getTemplates: () => {},
+  templates: [{ slug: 'mockSlug' }],
+  isGetting: true,
+  params: { slug: 'mockSlug' }
+});
+
+const wrapper = shallow(<TemplateView {...mockProps()} />);
+
+describe('(Container) TemplateView', () => {
+  it('renders without exploding', () => {
+    expect(wrapper).to.have.lengthOf(1);
+  });
+});

--- a/client/reducers/appReducer.spec.js
+++ b/client/reducers/appReducer.spec.js
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+
+import {
+  requestProfile,
+  completeProfile,
+  receiveNotification,
+  consumeNotification
+} from '../actions/appActions';
+
+import initialState from './initialState';
+import { profile } from './appReducer';
+
+describe('(Reducer/Action Creator) app', () => {
+
+// profile reducer
+
+  it('should handle REQUEST_WS_PROFILE', () => {
+    expect(
+      profile(undefined, requestProfile())
+    ).to.deep.equal({
+      ...initialState.profile
+    });
+  });
+
+  it('should handle COMPLETE_WS_PROFILE', () => {
+    const mockData = { something: 'something' };
+    expect(
+      profile(undefined, completeProfile(mockData))
+    ).to.deep.equal({ 
+      ...initialState.profile,
+      user: { ...mockData }
+    });
+  });
+
+  // it('should handle RECEIVE_WS_NOTIFICATION', () => {}):
+
+  // it('should handle CONSUME_WS_NOTIFICATION', () => {});
+
+});

--- a/client/reducers/campaignReducer.spec.js
+++ b/client/reducers/campaignReducer.spec.js
@@ -1,0 +1,185 @@
+import { expect } from 'chai';
+
+import {
+  requestPostCreateCampaign,
+  completePostCreateCampaign,
+  requestPostCreateTemplate,
+  completePostCreateTemplate,
+  requestGetCampaign,
+  completeGetCampaign,
+  completeDeleteCampaigns,
+  requestGetTemplates,
+  completeGetTemplates,
+  completeDeleteTemplates,
+  requestPostSendCampaign,
+  completePostSendCampaign,
+  requestPostSendTestEmail,
+  completePostSendTestEmail
+} from '../actions/campaignActions';
+
+import initialState from './initialState';
+
+import {
+  createCampaign,
+  createTemplate,
+  manageCampaign,
+  manageTemplates,
+  sendCampaign,
+  sendTest
+ } from './campaignReducer';
+
+describe('(Reducer/Action Creator) campaign', () => {
+
+// createCampaign reducer
+
+  it('should handle REQUEST_POST_CREATECAMPAIGN', () => {
+    expect(
+      createCampaign(undefined, requestPostCreateCampaign())
+    ).to.deep.equal({
+      ...initialState.createCampaign,
+      isPosting: true
+    });
+  });
+
+  it('should handle COMPLETE_POST_CREATECAMPAIGN', () => {
+    expect(
+      createCampaign(undefined, completePostCreateCampaign())
+    ).to.deep.equal({
+      ...initialState.createCampaign,
+      isPosting: false
+    });
+  });
+
+// createTemplate reducer
+
+  it('should handle REQUEST_POST_CREATETEMPLATE', () => {
+    expect(
+      createTemplate(undefined, requestPostCreateTemplate())
+    ).to.deep.equal({
+      ...initialState.createTemplate,
+      isPosting: true
+    });
+  });
+
+  it('should handle COMPLETE_POST_CREATETEMPLATE', () => {
+    expect(
+      createTemplate(undefined, completePostCreateTemplate())
+    ).to.deep.equal({
+      ...initialState.createTemplate,
+      isPosting: false
+    });
+  });
+
+// manageCampaign reducer
+
+  it('should handle REQUEST_GET_CAMPAIGNS', () => {
+    expect(
+      manageCampaign(undefined, requestGetCampaign())
+    ).to.deep.equal({
+      ...initialState.manageCampaign,
+      isGetting: true
+    });
+  });
+
+  it('should handle COMPLETE_GET_CAMPAIGNS', () => {
+    const mockCampaigns = 'something';
+    expect(
+      manageCampaign(undefined, completeGetCampaign(mockCampaigns))
+    ).to.deep.equal({
+      ...initialState.manageCampaign,
+      campaigns: mockCampaigns,
+      isGetting: false
+    });
+  });
+
+  it('should handle COMPLETE_DELETE_CAMPAIGNS', () => {
+    const mockCampaigns = 'something';
+    expect(
+      manageCampaign(undefined, completeDeleteCampaigns(mockCampaigns))
+    ).to.deep.equal({
+      ...initialState.manageCampaign,
+      campaigns: mockCampaigns
+    });
+  });
+
+// manageTemplates reducer
+
+  it('should handle REQUEST_GET_TEMPLATES', () => {
+    expect(
+      manageTemplates(undefined, requestGetTemplates())
+    ).to.deep.equal({
+      ...initialState.manageTemplates,
+      isGetting: true
+    });
+  });
+
+  it('should handle COMPLETE_GET_TEMPLATES', () => {
+    const mockTemplates = 'something';
+    expect(
+      manageTemplates(undefined, completeGetTemplates(mockTemplates))
+    ).to.deep.equal({
+      ...initialState.manageTemplates,
+      templates: mockTemplates,
+      isGetting: false
+    });
+  });
+
+  it('should handle COMPLETE_DELETE_TEMPLATES', () => {
+    const mockTemplates = 'something';
+    expect(
+      manageTemplates(undefined, completeDeleteTemplates(mockTemplates))
+    ).to.deep.equal({
+      ...initialState.manageTemplates,
+      templates: mockTemplates
+    });
+  });
+
+// sendCampaign reducer
+
+  it('should handle REQUEST_POST_SENDCAMPAIGN', () => {
+    expect(
+      sendCampaign(undefined, requestPostSendCampaign())
+    ).to.deep.equal({
+      ...initialState.sendCampaign,
+      isPosting: true
+    });
+  });
+
+  it('should handle REQUEST_POST_SENDCAMPAIGN', () => {
+    const mockSendCampaignResponse = 'something1';
+    const mockSendCampaignStatus = 'something2';
+    expect(
+      sendCampaign(undefined, completePostSendCampaign(mockSendCampaignResponse, mockSendCampaignStatus))
+    ).to.deep.equal({
+      ...initialState.sendCampaign,
+      isPosting: false,
+      sendCampaignResponse: mockSendCampaignResponse,
+      sendCampaignStatus: mockSendCampaignStatus
+    });
+  });
+
+// sendTest reducer
+
+  it('should handle REQUEST_POST_SENDTESTEMAIL', () => {
+    expect(
+      sendTest(undefined, requestPostSendTestEmail())
+    ).to.deep.equal({
+      ...initialState.sendTest,
+      isPosting: true
+    });
+  });
+
+  it('should handle COMPLETE_POST_SENDTESTEMAIL', () => {
+    const mockSendTestEmailResponse = 'something1';
+    const mockSendTestEmailStatus = 'something2';
+    expect(
+      sendTest(undefined, completePostSendTestEmail(mockSendTestEmailResponse, mockSendTestEmailStatus))
+    ).to.deep.equal({
+      ...initialState.sendTest,
+      isPosting: false,
+      sendTestEmailResponse: mockSendTestEmailResponse,
+      sendTestEmailStatus: mockSendTestEmailStatus
+    });
+  });
+
+});

--- a/client/reducers/listReducer.spec.js
+++ b/client/reducers/listReducer.spec.js
@@ -1,0 +1,117 @@
+import { expect } from 'chai';
+
+import {
+  requestGetListSubscribers,
+  completeGetListSubscribers,
+  completeDeleteListSubscribers,
+  requestAddSubscribers,
+  completeAddSubscribers,
+  requestGetList,
+  completeGetList,
+  completeDeleteLists
+} from '../actions/listActions';
+
+import initialState from './initialState';
+
+import {
+  manageListSubscribers,
+  createList,
+  manageList,
+ } from './listReducer';
+
+describe('(Reducer/Action Creator) list', () => {
+
+// manageListSubscribers reducer
+
+  it('should handle REQUEST_GET_LIST_SUBSCRIBERS', () => {
+    const mockListId = 'something';
+    expect(
+      manageListSubscribers(undefined, requestGetListSubscribers(mockListId))
+    ).to.deep.equal({
+      ...initialState.manageListSubscribers,
+      isGetting: true,
+      listId: mockListId
+    });
+  });
+
+  it('should handle COMPLETE_GET_LIST_SUBSCRIBERS', () => {
+    const mockSubscribers = 'something1';
+    const mockTotalListSubscribers = 'something2';
+    const mockAdditionalFields = 'something3';
+    expect(
+      manageListSubscribers(undefined, completeGetListSubscribers(mockSubscribers, mockTotalListSubscribers, mockAdditionalFields))
+    ).to.deep.equal({
+      ...initialState.manageListSubscribers,
+      isGetting: false,
+      subscribers: mockSubscribers,
+      totalListSubscribers: mockTotalListSubscribers,
+      additionalFields: mockAdditionalFields
+    });
+  });
+
+  it('should handle COMPLETE_DELETE_LIST_SUBSCRIBERS', () => {
+    const mockSubscribers = 'something';
+    expect(
+      manageListSubscribers(undefined, completeDeleteListSubscribers(mockSubscribers))
+    ).to.deep.equal({
+      ...initialState.manageListSubscribers,
+      subscribers: mockSubscribers
+    });
+  });
+
+// createList reducer
+
+  it('should handle REQUEST_ADD_SUBSCRIBERS', () => {
+    const mockUpload = 'something';
+    expect(
+      createList(undefined, requestAddSubscribers(mockUpload))
+    ).to.deep.equal({
+      ...initialState.createList,
+      isPosting: true,
+      upload: mockUpload
+    });
+  });
+
+  it('should handle COMPLETE_ADD_SUBSCRIBERS', () => {
+    expect(
+      createList(undefined, completeAddSubscribers())
+    ).to.deep.equal({
+      ...initialState.createList,
+      isPosting: false,
+      upload: null
+    });
+  });
+
+// manageList reducer
+
+  it('should handle REQUEST_GET_LISTS', () => {
+    expect(
+      manageList(undefined, requestGetList())
+    ).to.deep.equal({
+      ...initialState.manageList,
+      isGetting: true
+    });
+  });
+
+  it('should handle COMPLETE_GET_LISTS', () => {
+    const mockLists = 'something';
+    expect(
+      manageList(undefined, completeGetList(mockLists))
+    ).to.deep.equal({
+      ...initialState.manageList,
+      lists: mockLists,
+      isGetting: false
+    });
+  });
+
+  it('should handle COMPLETE_DELETE_LISTS', () => {
+    const mockLists = 'something';
+    expect(
+      manageList(undefined, completeDeleteLists(mockLists))
+    ).to.deep.equal({
+      ...initialState.manageList,
+      lists: mockLists
+    });
+  });
+
+});

--- a/client/reducers/notificationsReducer.spec.js
+++ b/client/reducers/notificationsReducer.spec.js
@@ -1,0 +1,43 @@
+import { expect } from 'chai';
+
+import {
+  notify,
+  consume
+} from '../actions/notificationActions';
+
+import initialState from './initialState';
+import notifications from './notificationsReducer';
+
+describe('(Reducer/Action Creator) notification', () => {
+
+// notifications reducer
+
+  it('should handle RECEIVE_NOTIFICATION', () => {
+    const mockNotification = { message: 'something1', colour: 'something2'};
+    const mockStackElement = {
+      message: mockNotification.message,
+      dismissAfter: 20000,
+      isActive: true,
+      activeBarStyle: {
+        background: 'crimson',
+        left: ''
+      }
+    };
+    expect(
+      notifications(undefined, notify(mockNotification))
+    ).to.deep.equal({
+      ...initialState.notifications,
+      stack: [ ...initialState.notifications.stack, mockStackElement ] 
+    });
+  });
+
+  it('should handle RECEIVE_NOTIFICATION', () => {
+    expect(
+      notifications(undefined, consume())
+    ).to.deep.equal({
+      ...initialState.notifications,
+      stack: initialState.notifications.stack.slice(1)
+    });
+  });
+
+});

--- a/client/reducers/permissionReducer.spec.js
+++ b/client/reducers/permissionReducer.spec.js
@@ -1,0 +1,257 @@
+import { expect } from 'chai';
+
+import {
+  requestGetGrantPermissions,
+  completeGetGrantPermissions,
+  requestPostGrantPermission,
+  completePostGrantPermission,
+  requestDeleteGrantPermission,
+  completeDeleteGrantPermission,
+  requestGetReceivedPermissionOffers,
+  completeGetReceivedPermissionOffers,
+  requestPostAcceptReceivedPermissionOffers,
+  completePostAcceptReceivedPermissionOffers,
+  requestDeleteRejectReceivedPermissionOffers,
+  completeDeleteRejectReceivedPermissionOffers,
+  requestGetActivePermissions,
+  completeGetActivePermissions,
+  requestDeleteActivePermissions,
+  completeDeleteActivePermissions,
+  requestGetGrantOfferedPermissions,
+  completeGetGrantOfferedPermissions,
+  requestDeleteGrantOfferedPermissions,
+  completeDeleteGrantOfferedPermissions,
+  activateAccount,
+  deactivateAccount
+} from '../actions/permissionActions';
+
+import initialState from './initialState';
+
+import {
+  grantPermissions,
+  receivedPermissionOffers,
+  activePermissions,
+  grantOfferedPermissions,
+  activeAccount
+ } from './permissionReducer';
+
+describe('(Reducer/Action Creator) permission', () => {
+
+// grantPermissions reducer
+
+  it('should handle REQUEST_GET_GRANT_PERMISSION', () => {
+    expect(
+      grantPermissions(undefined, requestGetGrantPermissions())
+    ).to.deep.equal({
+      ...initialState.grantPermissions,
+      isGetting: true
+    });
+  });
+
+  it('should handle COMPLETE_GET_GRANT_PERMISSION', () => {
+    const mockPayload = 'something';
+    expect(
+      grantPermissions(undefined, completeGetGrantPermissions(mockPayload))
+    ).to.deep.equal({
+      ...initialState.grantPermissions,
+      isGetting: false,
+      grantedPermissions: mockPayload
+    });
+  });
+
+  it('should handle REQUEST_POST_GRANT_PERMISSION', () => {
+    expect(
+      grantPermissions(undefined, requestPostGrantPermission())
+    ).to.deep.equal({
+      ...initialState.grantPermissions,
+      isPosting: true
+    });
+  });
+
+  it('should handle COMPLETE_POST_GRANT_PERMISSION', () => {
+    const mockPayload = 'something';
+    expect(
+      grantPermissions(undefined, completePostGrantPermission(mockPayload))
+    ).to.deep.equal({
+      ...initialState.grantPermissions,
+      isPosting: false,
+      response: mockPayload
+    });
+  });
+
+  it('should handle REQUEST_DELETE_GRANT_PERMISSION', () => {
+    expect(
+      grantPermissions(undefined, requestDeleteGrantPermission())
+    ).to.deep.equal({
+      ...initialState.grantPermissions
+    });
+  });
+
+  it('should handle COMPLETE_DELETE_GRANT_PERMISSION', () => {
+    const mockPayload = 'something';
+    expect(
+      grantPermissions(undefined, completeDeleteGrantPermission(mockPayload))
+    ).to.deep.equal({
+      ...initialState.grantPermissions,
+      grantedPermissions: mockPayload
+    });
+  });
+
+// receivedPermissionOffers reducer
+
+  it('should handle REQUEST_GET_RECEIVED_PERMISSION_OFFERS', () => {
+    expect(
+      receivedPermissionOffers(undefined, requestGetReceivedPermissionOffers())
+    ).to.deep.equal({
+      ...initialState.receivedPermissionOffers,
+      isGetting: true
+    });
+  });
+
+  it('should handle COMPLETE_GET_RECEIVED_PERMISSION_OFFERS', () => {
+    const mockPayload = 'something';
+    expect(
+      receivedPermissionOffers(undefined, completeGetReceivedPermissionOffers(mockPayload))
+    ).to.deep.equal({
+      ...initialState.receivedPermissionOffers,
+      isGetting: false,
+      receivedPermissionOffers: mockPayload
+    });
+  });
+
+  it('should handle REQUEST_POST_ACCEPT_RECEIVED_PERMISSION_OFFERS', () => {
+    expect(
+      receivedPermissionOffers(undefined, requestPostAcceptReceivedPermissionOffers())
+    ).to.deep.equal({
+      ...initialState.receivedPermissionOffers
+    });
+  });
+
+  it('should handle COMPLETE_POST_ACCEPT_RECEIVED_PERMISSION_OFFERS', () => {
+    const mockPayload = 'something';
+    expect(
+      receivedPermissionOffers(undefined, completePostAcceptReceivedPermissionOffers(mockPayload))
+    ).to.deep.equal({
+      ...initialState.receivedPermissionOffers,
+      receivedPermissionOffers: mockPayload
+    });
+  });
+
+  it('should handle REQUEST_DELETE_REJECT_RECEIVED_PERMISSION_OFFERS', () => {
+    expect(
+      receivedPermissionOffers(undefined, requestDeleteRejectReceivedPermissionOffers())
+    ).to.deep.equal({
+      ...initialState.receivedPermissionOffers
+    });
+  });
+
+  it('should handle COMPLETE_DELETE_REJECT_RECEIVED_PERMISSION_OFFERS', () => {
+    const mockPayload = 'something';
+    expect(
+      receivedPermissionOffers(undefined, completeDeleteRejectReceivedPermissionOffers(mockPayload))
+    ).to.deep.equal({
+      ...initialState.receivedPermissionOffers,
+      receivedPermissionOffers: mockPayload
+    });
+  });
+
+// activePermissions reducer
+
+  it('should handle REQUEST_GET_ACTIVE_PERMISSIONS', () => {
+    expect(
+      activePermissions(undefined, requestGetActivePermissions())
+    ).to.deep.equal({
+      ...initialState.activePermissions,
+      isGetting: true
+    });
+  });
+
+  it('should handle COMPLETE_GET_ACTIVE_PERMISSIONS', () => {
+    const mockPayload = 'something';
+    expect(
+      activePermissions(undefined, completeGetActivePermissions(mockPayload))
+    ).to.deep.equal({
+      ...initialState.activePermissions,
+      activePermissions: mockPayload
+    });
+  });
+
+  it('should handle REQUEST_DELETE_ACTIVE_PERMISSIONS', () => {
+    expect(
+      activePermissions(undefined, requestDeleteActivePermissions())
+    ).to.deep.equal({
+      ...initialState.activePermissions
+    });
+  });
+
+  it('should handle COMPLETE_DELETE_ACTIVE_PERMISSIONS', () => {
+    const mockPayload = 'something';
+    expect(
+      activePermissions(undefined, completeDeleteActivePermissions(mockPayload))
+    ).to.deep.equal({
+      ...initialState.activePermissions,
+      activePermissions: mockPayload
+    });
+  });
+
+// grantOfferedPermissions reducer
+
+  it('should handle REQUEST_GET_GRANT_OFFERED_PERMISSIONS', () => {
+    expect(
+      grantOfferedPermissions(undefined, requestGetGrantOfferedPermissions())
+    ).to.deep.equal({
+      ...initialState.grantOfferedPermissions,
+      isGetting: true
+    });
+  });
+
+  it('should handle COMPLETE_GET_GRANT_OFFERED_PERMISSIONS', () => {
+    const mockPayload = 'something';
+    expect(
+      grantOfferedPermissions(undefined, completeGetGrantOfferedPermissions(mockPayload))
+    ).to.deep.equal({
+      ...initialState.grantOfferedPermissions,
+      isGetting: false,
+      grantOfferedPermissions: mockPayload
+    });
+  });
+
+  it('should handle REQUEST_DELETE_GRANT_OFFERED_PERMISSIONS', () => {
+    expect(
+      grantOfferedPermissions(undefined, requestDeleteGrantOfferedPermissions())
+    ).to.deep.equal({
+      ...initialState.grantOfferedPermissions
+    });
+  });
+
+  it('should handle COMPLETE_DELETE_GRANT_OFFERED_PERMISSIONS', () => {
+    const mockPayload = 'something';
+    expect(
+      grantOfferedPermissions(undefined, completeDeleteGrantOfferedPermissions(mockPayload))
+    ).to.deep.equal({
+      ...initialState.grantOfferedPermissions,
+      grantOfferedPermissions: mockPayload
+    });
+  });
+
+// activeAccount reducer
+
+  it('should handle ACTIVATE_ACCOUNT', () => {
+    const mockPayload = { something: 'something' };
+    expect(
+      activeAccount(undefined, activateAccount(mockPayload))
+    ).to.deep.equal({
+      ...initialState.activeAccount,
+      ...mockPayload
+    });
+  });
+
+  it('should handle DEACTIVATE_ACCOUNT', () => {
+    expect(
+      activeAccount(undefined, deactivateAccount())
+    ).to.deep.equal({
+      ...initialState.activeAccount
+    });
+  });
+
+});

--- a/client/reducers/settingsReducer.spec.js
+++ b/client/reducers/settingsReducer.spec.js
@@ -1,0 +1,47 @@
+import { expect } from 'chai';
+
+import {
+  requestChangeSettings,
+  receiveChangeSettings,
+  updateSettingsFieldsExist
+} from '../actions/settingsActions';
+
+import initialState from './initialState';
+
+import settings from './settingsReducer';
+
+describe('(Reducer/Action Creator) settings', () => {
+
+// settings reducer
+
+  it('should handle SETTINGS_CHANGE_REQUEST', () => {
+    expect(
+      settings(undefined, requestChangeSettings())
+    ).to.deep.equal({
+      ...initialState.settings,
+      loading: true
+    });
+  });
+
+  it('should handle SETTINGS_CHANGE_RECEIVE', () => {
+    const mockStatus = { something: 'something' };
+    expect(
+      settings(undefined, receiveChangeSettings(mockStatus))
+    ).to.deep.equal({
+      ...initialState.settings,
+      loading: false,
+      status: ''
+    });
+  });
+
+  it('should handle SETTINGS_UPDATE_FIELDS_EXIST', () => {
+    const mockPayload = 'something';
+    expect(
+      settings(undefined, updateSettingsFieldsExist(mockPayload))
+    ).to.deep.equal({
+      ...initialState.settings,
+      fieldsExist: mockPayload
+    });
+  });
+
+});


### PR DESCRIPTION
Here are some minimal tests for components, containers, and reducer/action creators. 
Included component/container tests confirm component renders without error.
Included reducer tests confirm that reducer/action creator combination produces desired result in default case. More tests can be added to these files in the future to test additional cases.

Tests on async operations in files within /client/actions are still needed but testing these will require more work to figure out mocking of http responses. I have created placeholder files within/client/actions that import the functions that still require testing.

Container components have been modified to not use decorators which allows directly importing undecorated component for testing. I found some sources suggesting the possibility of testing decorated components with Enzyme but I wasn't able to get this working.

Let me know if I should squash both commits into one.