### PR TITLE
Implement white list

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,10 @@ GOOGLE_CONSUMER_KEY=
 GOOGLE_CONSUMER_SECRET=
 GOOGLE_CALLBACK=
 
+# To prevent anyone to send mail at the cost of the instance owner only white listed emails can log in
+# The emails are separated by ',' like so : ernest@hemingway.com,ada@lovelace.com,george@orwell.com
+WHITELISETEDEMAILS=
+
 # Postgres user and database information
 # - These variables should match your Postgres configuration
 #

--- a/server/config/passport/google.js
+++ b/server/config/passport/google.js
@@ -7,6 +7,10 @@ module.exports = (passport, secret) => {
     clientSecret: secret.consumerSecret,
     callbackURL: secret.callbackURL,
   }, (token, tokenSecret, profile, done) => {
+    //Check if the user has the privilege to log in
+    if (!db.user.isWhiteListed(profile.emails)) {
+      return done(null,false);
+    }
     db.user.findOne({
       where: {
         googleId: profile.id

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -11,6 +11,29 @@ module.exports = function(sequelize, DataTypes) {
     classMethods: {
       associate: function(models) {
         // associations can be defined here
+      },
+
+      //check the .env to check if the user behind the given mail has the privilege to log in
+      isWhiteListed: function (emails) {
+        //the white listed emails are stored in the .env file as a string
+        //example : 'ernest@hemingway.com,ada@lovelace.com,george@orwell.com'
+
+        //array-ify the environemental variable
+        const whiteListedEmails = process.env.WHITELISTEDEMAILS.split(',');
+
+        //emails is an array of objects like [{value:'jon@doe.com',type:'account'}]
+        //here we only keep the mails and put them in an array
+        const clientsMails = emails.map((mail)=>{
+          return mail.value;
+        });
+
+        //here we create an array containing the intersection of the white listed email and the provided emails
+        const intersection =  clientsMails.filter((mail)=>{
+          return whiteListedEmails.indexOf(mail) !== -1;
+        });
+
+        //if the intersection is empty the user isn't white listed
+        return intersection.length !== 0;
       }
     }
   });


### PR DESCRIPTION
In order to restrain everybody to access mail for good and send email at the cost of the platform owner, here is a simple system to whitelist the emails usable to log into a given mail for good instance.