### PR TITLE
Make Postgres and Redis hosts configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ GOOGLE_CALLBACK=
 # Postgres user and database information
 # - These variables should match your Postgres configuration
 #
+# PSQL_HOST=
 # PSQL_USERNAME=
 # PSQL_PASSWORD=
 # PSQL_DATABASE=

--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,11 @@ GOOGLE_CALLBACK=
 # PSQL_PASSWORD=
 # PSQL_DATABASE=
 
+# Redis configuration (optional, uses localhost by default)
+# REDIS_HOST=
+# REDIS_PORT=
+# REDIS_PASSWORD=
+
 # AWS keys are encrypted in the database using this user-specified password.
 # - Generate a random password and provide it here.
 #

--- a/server/config/server/redis.js
+++ b/server/config/server/redis.js
@@ -1,7 +1,11 @@
 const redis = require('redis');
 
 module.exports = () => {
-  const redisSettings = { host: process.env.REDIS_HOST || '127.0.0.1' };
+  const redisSettings = {
+    host: process.env.REDIS_HOST || '127.0.0.1',
+    port: process.env.REDIS_PORT,
+    password: process.env.REDIS_PASSWORD,
+  };
   const client = redis.createClient(redisSettings);
   const subscriber = redis.createClient(redisSettings);  // Need to create separate connections
   const publisher = redis.createClient(redisSettings);   // for pub-sub


### PR DESCRIPTION
I prefer to use my own cloud-hosted postgres server and Redis host. This commit makes it possible to configure your own postgres/redis settings in your `.env` file. That's it! Tested and works.