### PR TITLE
Disambiguate port usage in GOOGLE_CALLBACK in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@
 # GOOGLE_CONSUMER_KEY=dlkjxaxxxxxxxxdlkfjalskjda9sokpopr.apps.googleusercontent.com
 # GOOGLE_CONSUMER_SECRET=XoDoijdasdj_ooPwerO
 # GOOGLE_CALLBACK=http://localhost/auth/google/callback
+# if you aim to contribute and run the project via npm then use : GOOGLE_CALLBACK=http://localhost:8080/auth/google/callback
 GOOGLE_CONSUMER_KEY=
 GOOGLE_CONSUMER_SECRET=
 GOOGLE_CALLBACK=


### PR DESCRIPTION
put an additionnal line in the .env.example to clarify that you have to use the 8080 port for the authentication callback as opposed to the port 80 used when the app is runned via docker