### PR TITLE
Fix: run the campaign reports consumer

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "check-env-file": "python ./tools/setup/initial_setup.py",
     "client:lint": "esw webpack.config.* client tools --color",
     "client:clean-dist": "npm run client:remove-dist && mkdir dist",
-    "start": "NODE_ENV=production npm-run-all start:*",
+    "start": "NODE_ENV=production npm-run-all --parallel start:*",
     "start:main": "node server/index.js",
     "start:consumer": "node server/feedback-consumer/consumer.js",
     "production": "DEV_SEND_RATE=200 TEST_PRODUCTION=true NODE_ENV=production node server/index.js",


### PR DESCRIPTION
```npm start``` doesn't start the campaign reports consumer, probably leading to some of the issues encountered in #226.

It seems that ```npm-run-all``` in ```package.json``` runs [sequentially by default](https://github.com/mysticatea/npm-run-all/blob/HEAD/docs/npm-run-all.md#run-scripts-sequentially), so the feedback consumer is never started (it just waits for server/index.js to finish).

This PR just adds the ```--parallel``` flag to the ```npm start``` command so both the server and feedback consumer start together.