### PR TITLE
fix: Extra space in x-forwarded-for

### DIFF
--- a/server/controllers/analytics/open.js
+++ b/server/controllers/analytics/open.js
@@ -18,7 +18,7 @@ module.exports = function(req, res) {
       foundCampaignAnalyticsOpen.opened = true;
 
       // Attempt to get ip
-      const ipAddress = req.headers['x -forwarded-for'] ||
+      const ipAddress = req.headers['x-forwarded-for'] ||
         req.connection.remoteAddress ||
         req.socket.remoteAddress ||
         req.connection.socket.remoteAddress;


### PR DESCRIPTION
Open Tracking not working 

```js
Unhandled Rejection at: Promise Promise {
_bitField: 20185088,
 _fulfillmentHandler0: TypeError: Cannot read property 'remoteAddress' of undefined
at Model.CampaignAnalyticsOpen.findOne.then.foundCampaignAnalyticsOpen (/home/user/mail-for-good/server/controllers/analytics/open.js:24:31)

```