### PR TITLE
Improve email validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "debug": "^2.6.8",
     "dompurify": "^0.9.0",
     "dotenv": "^4.0.0",
+    "email-validator": "^1.1.1",
     "express": "^4.15.3",
     "express-session": "^1.15.3",
     "geoip-lite": "^1.2.1",


### PR DESCRIPTION
This is an improvement over the previous regex check against emails. The intention is to prevent malformed emails from being imported, without inhibiting the user's experience.

I have also fixed the previous unit test for the import CSV function by stubbing the 'io' object (it's somewhat of a hack, apologies).