### PR TITLE
fix admin creation on first launch

### DIFF
--- a/server/config/server/sequelize.js
+++ b/server/config/server/sequelize.js
@@ -2,19 +2,6 @@ const db = require('../../models');
 
 module.exports = () => {
   const { sequelize } = db;
-  
-  sequelize.sync({force:false})
-  .then(createDefaultAdminIfNeeded())
-};
 
-async function createDefaultAdminIfNeeded() {
-   const anAdmin = await db.user.findOne({where:{isAdmin:true}})
-   if(anAdmin === null){
-     db.user.createOne({
-       email:'admin@admin.com',
-       name:'admin',
-       password:'admin',
-       isAdmin:true
-     })
-   }
-}
+  sequelize.sync({force:false,hooks:true})
+};

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -19,6 +19,21 @@ module.exports = function(sequelize, DataTypes) {
     }
   });
 
+  User.addHook('afterSync',() => {
+    User.findOne({where:{isAdmin:true}})
+    .then((anAdmin)=>{
+      if(anAdmin === null){
+          User.createOne({
+          email:'admin@admin.com',
+          name:'admin',
+          password:'admin',
+          isAdmin:true
+        })
+      }
+    })
+    return null
+  })
+
   //returns Promise(isValid:boolean)
   User.checkPassword = (plainTextPassword, hash) => {
     return bcrypt.compare(plainTextPassword, hash);


### PR DESCRIPTION
previously the default admin was created only if the DB was existing prior to the launch (i.e default admin wasn't created on the first post-deploy launch. You had to deploy -> start app -> restart app)