### PR TITLE
Added information about the data charges of AWS Simple Email Service.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Looking to contribute? Read our [developer setup guide](https://github.com/freeC
 
 ![Image showing Mail 4 Good](docs/resources/hero.png)
 
-An app for sending millions of emails as cheaply as possible. Mail for Good uses AWS Simple Email Service to send bulk emails at $0.10 per 1000 emails.
+An app for sending millions of emails as cheaply as possible. Mail for Good uses AWS Simple Email Service to send bulk emails at $0.10 per 1000 emails and an additional $0.12 for each GB of data sent (headers, email content and attachments).
 
 Mail for Good is fast and memory efficient, currently sending over 100 emails per second on a 1gb Digital Ocean VPS.
 


### PR DESCRIPTION
AWS Simple Email Service charges for data in addition to the count of emails. If we include this in the README, people can know it beforehand.